### PR TITLE
RCC/TSC:

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             "debugger_args": [
                 "-nx" // dont use the .gdbinit file
             ],
-            "executable": "./target/thumbv7em-none-eabi/debug/examples/touch",
+            "executable": "./target/thumbv7em-none-eabi/debug/examples/serial",
             "remote": true,
             "target": ":3333",
             "cwd": "${workspaceRoot}",
@@ -34,7 +34,7 @@
             "debugger_args": [
                 "-nx" // dont use the .gdbinit file
             ],
-            "executable": "./target/thumbv7em-none-eabi/release/examples/touch",
+            "executable": "./target/thumbv7em-none-eabi/release/examples/serial",
             "remote": true,
             "target": ":3333",
             "cwd": "${workspaceRoot}",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ exclude = [
 [dependencies]
 cortex-m = "0.5.2"
 nb = "0.1.1"
-cortex-m-rt = "0.5.1"
 
 [dependencies.cast]
 version  = "0.2.2"
@@ -38,6 +37,7 @@ features = ["stm32l4x2", "rt"]
 [dev-dependencies]
 panic-semihosting = "0.3.0"
 cortex-m-semihosting = "0.3.0"
+cortex-m-rt = "0.5.1"
 
 [profile.dev]
 incremental = false

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -34,9 +34,9 @@ fn main() -> ! {
     // let mut gpiob = p.GPIOB.split(&mut rcc.ahb2);
 
     // clock configuration using the default settings (all clocks run at 8 MHz)
-    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+    // let clocks = rcc.cfgr.freeze(&mut flash.acr);
     // TRY this alternate clock configuration (clocks run at nearly the maximum frequency)
-    // let clocks = rcc.cfgr.sysclk(64.mhz()).pclk1(32.mhz()).freeze(&mut flash.acr);
+    let clocks = rcc.cfgr.sysclk(80.mhz()).pclk1(80.mhz()).pclk2(80.mhz()).freeze(&mut flash.acr);
 
     // The Serial API is highly generic
     // TRY the commented out, different pin configurations

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -44,7 +44,7 @@ fn main() -> ! {
     // let mut c3 = gpiob.pb7.into_touch_channel(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
     
     // , (c1, c2, c3) 
-    let tsc = Tsc::tsc(p.TSC, sample_pin, &mut rcc.ahb1);
+    let tsc = Tsc::tsc(p.TSC, sample_pin, &mut rcc.ahb1, None);
 
     let baseline = tsc.acquire(&mut c1).unwrap();
     let threshold = (baseline / 100) * 60;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -351,10 +351,10 @@ impl CFGR {
             .modify(|_, w| unsafe { 
                 w.pllsrc()
                     .bits(pllsrc_bits)
-                    .pllm().bits(pllmul_bits)
+                    .pllm().bits(0b0) // no division, how to calculate?
+                    .pllr().bits(0b0) // no division, how to calculate?
+                    .plln().bits(pllmul_bits)
             });
-            // .plln().bits(n) // TODO?
-            // .pllr().bits(r)
 
             rcc.cr.modify(|_, w| w.pllon().set_bit());
             


### PR DESCRIPTION
	- Fixed pll multiplyer issue with RCC, the PLL now properly
represents the stored values the user sets. This also closes
https://github.com/MabezDev/stm32l432xx-hal/issues/14 .

	- TSC:
	   At higher clocks the TSC reading would be come erratic so I
have added a TSC config, which currently allowsa the clock prescaler to
be set & the max count error value to be set.